### PR TITLE
Renamed requiremts. Pinned SQLAlchemy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ openai
 plotly
 python_dotenv
 sendgrid
-sqlalchemy
+sqlalchemy==1.4.49
 psycopg2-binary


### PR DESCRIPTION
Renamed requirement.txt  filename to requirements.txt

Pinned version 1.4.49 of SQLAlchemy as I got the following warning on the console:

UserWarning: SQLAlchemy v2.0.0 or later is not yet supported by Great Expectations.