### PR TITLE
Unicodedecode error windows

### DIFF
--- a/great_expectations/app.py
+++ b/great_expectations/app.py
@@ -25,7 +25,7 @@ st.set_page_config(
 st.title("❄️ BirdiDQ")
 st.markdown('<h1 style="font-size: 24px; font-weight: bold; margin-bottom: 0;">Welcome to your DQ App</h1>', unsafe_allow_html=True)
 
-with open("great_expectations/ui/side.md", "r") as sidebar_file:
+with open("great_expectations/ui/side.md", "r", encoding="utf-8") as sidebar_file:
     sidebar_content = sidebar_file.read()
 
 # Display the DDL for the selected table

--- a/great_expectations/ui/side.md
+++ b/great_expectations/ui/side.md
@@ -1,6 +1,6 @@
 # About 🔍
 
-BirdiDQ is an intuitive and user-friendly data quality application that allows you to run data quality checks on top of python great expectation open source library using natural language queries. Type in your requests, and BirdiDQ will generate the appropriate GE method, run the quality control and return the results along with data docs you need. 
+BirdiDQ is an intuitive and user-friendly data quality application that allows you to run data quality checks on top of python great expectation open source library using natural language queries. Type in your requests, and BirdiDQ will generate the appropriate GE method, run the quality control and return the results along with data docs you need.
 
 ## Features
 
@@ -11,13 +11,16 @@ BirdiDQ is an intuitive and user-friendly data quality application that allows y
 - **GEN AI models**: Uses finetuned LLM on customed expectations data.
 
 ## Tech Stack
+
 This app is an LLM-powered app built using:
+
 - **[Streamlit](https://streamlit.io/)**
 - **[Great Expectations](https://github.com/Soulter/hugging-chat-api)**
 - **Finetuned LLMs**:
-    - **[Falcon-7B parameters causal decoder-only model](https://huggingface.co/tiiuae/falcon-7b)**: The model is finetuned on custom data with **Qlora** approach.
-    - **[OpenAI GPT-3](https://platform.openai.com/docs/guides/fine-tuning)**: Also finetuned on the same data
+  - **[Falcon-7B parameters causal decoder-only model](https://huggingface.co/tiiuae/falcon-7b)**: The model is finetuned on custom data with **Qlora** approach.
+  - **[OpenAI GPT-3](https://platform.openai.com/docs/guides/fine-tuning)**: Also finetuned on the same data
 - **Note**: The finetuned GPT-3 model seems to perform better for now.
+
 ## Queries example
 
 Here are some example queries you can try with BirdiDQ:


### PR DESCRIPTION
Streamlit in Windows tries to use cp1252 to load the sidebar.md. This fails as there are some emojis and special characters. Switching to unicode should fix this.

I also linted the sidebar.md, removing some spaces and adding some new lines where required.